### PR TITLE
boards: thingy91: moved board specific kconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ zephyr_include_directories(mqtt gnss datatypes pmic) # can also do this with mul
 target_sources(app PRIVATE src/main.c
             src/datatypes/datatypes.c
             src/mqtt/mqtt_connection.c
-            src/gnss/gnss.c
-            src/pmic/pmic.c)
+            src/gnss/gnss.c)
+
+target_sources_ifdef(CONFIG_ADP536X app PRIVATE src/pmic/pmic.c)
 # NORDIC SDK APP END

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 - [Web manpage](https://docs.nordicsemi.com/category/thingy91-category)
 - [Downloads (incl. schematic)](https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91/Download)
 
-*Should work on a 9160dk, but you need to remove the pmic config in `prj.conf`*
-
 ## Overview
 This example code monitors the state of LED1, battery percentage (via thingy91 onboard pmic), and geographical location.
 
@@ -19,11 +17,23 @@ However, there is a UDP+GNSS, COAP+GNSS, but not an MQTT+GNSS. Asset Tracker v2 
 ## Configuring
 Select your endpoint via prj.conf and the kconfigs `CONFIG_MQTT_PUB_TOPIC` and `CONFIG_MQTT_SUB_TOPIC`.
 
-If you want to run this on a 9160DK, you need to remove the PMIC module and disable the kconfig `CONFIG_ADP536X`.
-
 [Kconfig](https://github.com/droidecahedron/thingy91_mqtt_simple/blob/main/Kconfig) has most of the configurations around timing.
 [prj.conf](https://github.com/droidecahedron/thingy91_mqtt_simple/blob/main/prj.conf) has the rest.
 
+
+## Building
+
+For the Thingy91:
+
+```
+$ west build -b thingy91/nrf9160/ns -p auto
+```
+
+For the nRF9160-DK
+
+```
+$ west build -b nrf9160dk/nrf9160/ns -p auto
+```
 
 ##  Usage
 

--- a/boards/thingy91_nrf9160_ns.conf
+++ b/boards/thingy91_nrf9160_ns.conf
@@ -1,0 +1,2 @@
+# thingy91 is equipped with an adp536x i2c pmic. If you are on a 9160DK, you want to disable this.
+CONFIG_ADP536X=y

--- a/prj.conf
+++ b/prj.conf
@@ -70,6 +70,3 @@ CONFIG_LTE_PSM_REQ_RPTAU="00101000"
 # 1 1 1 – Value indicates that the timer is deactivated
 CONFIG_LTE_PSM_REQ_RAT="00001000"
 
-# PMIC
-# thingy91 is equipped with an adp536x i2c pmic. If you are on a 9160DK, you want to disable this.
-CONFIG_ADP536X=y


### PR DESCRIPTION
Moved the regulator Kconfig from prj.conf to
a board specific overlay for the thingy91's PMIC.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
